### PR TITLE
Disks will now be added to TARALLO if not present

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 pytarallo = "*"
+nose = "*"
 python-dotenv = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "603c05d6835295c50367f87b817342b3e7b5c6fb7723d557e36dc01e28a98683"
+            "sha256": "caef0d71ce9b3bd8c088a003dd03a19f6dca5d8cc7b76ba4fca2454ae07b22c9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.4.5.1"
         },
         "chardet": {
             "hashes": [
@@ -32,10 +32,19 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
+        },
+        "nose": {
+            "hashes": [
+                "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac",
+                "sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a",
+                "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"
+            ],
+            "index": "pypi",
+            "version": "==1.3.7"
         },
         "pytarallo": {
             "hashes": [
@@ -47,25 +56,25 @@
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:debd928b49dbc2bf68040566f55cdb3252458036464806f4094487244e2a4093",
-                "sha256:f157d71d5fec9d4bd5f51c82746b6344dffa680ee85217c123f4a0c8117c4544"
+                "sha256:81822227f771e0cab235a2939f0f265954ac4763cafd806d845801c863bf372f",
+                "sha256:92b3123fb2d58a284f76cc92bfe4ee6c502c32ded73e8b051c4f6afc8b6751ed"
             ],
             "index": "pypi",
-            "version": "==0.10.3"
+            "version": "==0.12.0"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         }
     },
     "develop": {}

--- a/config.json
+++ b/config.json
@@ -1,4 +1,0 @@
-{
-  "url": "http://localhost:8080",
-  "token": "2isWWogRDNscqYRpgpa8Zw:hzRDuhmpjFaxcuqVUwIV6Jmyuo5VcBVxqSvIRPxZIF8"
-}

--- a/smartctl_filegen.sh
+++ b/smartctl_filegen.sh
@@ -9,13 +9,17 @@ else
     echo -n "Unexpected number of parameters.\nUsage: sudo ./generate_files.sh /optional/path/to/files"
 fi
 
+[ ! -d $OUTPATH ] && mkdir $OUTPATH
+
 # removing all old smartctl files before writing new ones
 rm -f "$OUTPATH"/smartctl-dev-*.txt
 
 DISKZ=($(lsblk -d -I 8 -o NAME -n))
 echo Found $((${#DISKZ[@]}-1)) disks # count reduced by 1 to ignore sda
 for d in "${DISKZ[@]}"; do
-  if [ $d != "sda" ]; then # skips sda to avoid wiping system data
+  #if [ $d != "sda" ]; then # skips sda to avoid wiping system data
 	  smartctl -x /dev/$d > "$OUTPATH/smartctl-dev-$d.txt"
-	fi
+	#fi
 done
+
+exit 0

--- a/smartctl_filegen.sh
+++ b/smartctl_filegen.sh
@@ -15,11 +15,9 @@ fi
 rm -f "$OUTPATH"/smartctl-dev-*.txt
 
 DISKZ=($(lsblk -d -I 8 -o NAME -n))
-echo Found $((${#DISKZ[@]}-1)) disks # count reduced by 1 to ignore sda
+echo Found $((${#DISKZ[@]})) disks
 for d in "${DISKZ[@]}"; do
-  #if [ $d != "sda" ]; then # skips sda to avoid wiping system data
 	  smartctl -x /dev/$d > "$OUTPATH/smartctl-dev-$d.txt"
-	#fi
 done
 
 exit 0

--- a/smartctl_filegen.sh
+++ b/smartctl_filegen.sh
@@ -12,7 +12,7 @@ fi
 [ ! -d $OUTPATH ] && mkdir $OUTPATH
 
 # removing all old smartctl files before writing new ones
-rm -f "$OUTPATH"/smartctl-dev-*.txt
+rm -f "$OUTPATH"/*.txt
 
 DISKZ=($(lsblk -d -I 8 -o NAME -n))
 echo Found $((${#DISKZ[@]})) disks

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -74,13 +74,14 @@ def parse_disks(interactive: bool = False, ignore: list = [], usbdebug: bool = F
 
             # Ignoring disks pointed on call
             ignored = False
-            for sd in ignore:
-                if sd in filename:
+            for mount_point in ignore:
+                if mount_point in filename:
                     ignored = True
                     break
             if ignored is True:
                 if interactive is True:
-                    print("Disk mounted at /dev/"+sd+" ignored")
+                    print("Disk mounted at /dev/"+mount_point+" ignored")
+                os.remove(smartctl_path+"/"+filename)
                 continue
 
             # File reading
@@ -95,13 +96,18 @@ def parse_disks(interactive: bool = False, ignore: list = [], usbdebug: bool = F
             if '=== START OF INFORMATION SECTION ===' not in output:
                 if usbdebug is True:
                     disk = dummy_disk()
-                elif interactive:
-                    print(f"{filename} does not contain disk information, was it a USB stick?")
+                else:
+                    if interactive:
+                        print(f"{filename} does not contain disk information, was it a USB stick?")
                     continue
             else:
                 disk = read_smartctl(output)
 
             disk.dev = filename.split("smartctl-dev-")[1].split(".txt")[0]
+
+            old_filename = "smartctl/" + filename
+            new_filename = "smartctl/" + disk.serial_number + ".txt"
+            os.rename(old_filename, new_filename)
 
             disks.append(disk)
 
@@ -349,4 +355,4 @@ def main():
 
 
 if __name__ == '__main__':
-    print(main())
+    main()

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -206,7 +206,6 @@ def read_smartctl(path: str, interactive: bool = False):
                 "wwn": disk.wwn,
                 "sn": disk.serial_number,
                 "capacity-byte": disk.capacity,
-                "human_readable_capacity": disk.human_readable_capacity,
                 "smart-data": disk.smart_data.value
             }
             if disk.smart_data_long is not SMART.not_available:
@@ -222,7 +221,6 @@ def read_smartctl(path: str, interactive: bool = False):
                 # Despite the name it's still in bytes, but with SI prefix (not power of 2), "deci" is there just to
                 # tell some functions how to convert it to human-readable format
                 "capacity-decibyte": disk.capacity,
-                "human_readable_capacity": disk.human_readable_capacity,
                 "spin-rate-rpm": disk.rotation_rate,
                 "smart-data": disk.smart_data.value
             }
@@ -233,7 +231,10 @@ def read_smartctl(path: str, interactive: bool = False):
             this_disk[disk.port.value] = 1
         if disk.smart_data_long is not SMART.not_available:
             this_disk['notes'] = disk.smart_data_long
+        this_disk = {k: v for k, v in this_disk.items() if v != '' and v is not None}
         result.append(this_disk)
+
+
     return result
 
 

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,184 @@
+import os
+from dotenv import load_dotenv
+from pytarallo.Tarallo import Tarallo, Item
+from pytarallo.Errors import *
+import turbofresa
+from smartctl_parser import parse_disks, SMART
+
+from nose.plugins.skip import SkipTest
+
+
+class Test_Tarallo:
+    """
+    Used to verify intereactions between TARALLO and TURBOFRESA
+
+    !!!WARNING!!!
+    Only run this on a test version of the TARALLO!!!
+    """
+
+    def setup(self):
+        if not self.connected:
+            raise SkipTest("Not connected to TARALLO")
+
+    def teardown(self):
+        if self.connected:
+            codes = self.tarallo_instance.get_codes_by_feature('sn', self.dummy_disk['sn'])
+            if len(codes) > 1:
+                for code in codes:
+                    self.tarallo_instance.remove_item(code)
+            elif len(codes) == 1:
+                self.tarallo_instance.remove_item(codes)
+
+    @classmethod
+    def setup_class(cls):
+        cls.dummy_disk = {
+            'brand': 'PYTHON_TEST',
+            'capacity-byte': 1,
+            'hdd-form-factor': '2.5-7mm',
+            'model': 'TEST',
+            'sata-ports-n': 1,
+            'smart-data': SMART.working,
+            'sn': 'USB123456',
+            'type': 'ssd',
+        }
+
+        load_dotenv()
+        tarallo_url = os.getenv("TARALLO_URL")
+        tarallo_token = os.getenv("TARALLO_TOKEN")
+        try:
+            cls.tarallo_instance = Tarallo(tarallo_url, tarallo_token)
+        except:
+            cls.connected = False
+        else:
+            if cls.tarallo_instance.status() == 200:
+                cls.connected = True
+            else:
+                cls.connected = False
+        finally:
+            if cls.connected is False:
+                print("Couldn't connect to tarallo server")
+
+    def test_add_disk(self):
+        """
+        Simple disk addition to TARALLO through the TURBOFRESA
+        """
+        disk = self.dummy_disk
+
+        assert turbofresa.add_to_tarallo(self.tarallo_instance, disk) is True
+
+        disk_code = self.tarallo_instance.get_codes_by_feature('sn', disk['sn'])
+        assert len(disk_code) == 1
+
+    def test_add_duplicate(self):
+        """
+        Check if TURBOFRESA refuses to add a duplicate disk (with the same specs),
+        but anyway continues to wipe it
+        """
+        disk = self.dummy_disk
+
+        item = Item()
+        item.features = disk
+        item.location = 'Magazzino'
+
+        try:
+            self.tarallo_instance.add_item(item=item)
+            print("Item inserted successfully")
+        except ValidationError:
+            print("Item not inserted")
+            response = self.tarallo_instance.response
+            print("HTTP status code:", response.status_code, "\n" + response.json()['message'])
+            raise AssertionError("Failed to manually add disk to TARALLO")
+
+        assert turbofresa.add_to_tarallo(self.tarallo_instance, disk) is True, "Failed to add disk through" \
+                                                                               "TURBOFRESA"
+
+        disk_code = self.tarallo_instance.get_codes_by_feature('sn', disk['sn'])
+        assert len(disk_code) == 1, "Disk added by error"
+
+    def test_add_conflicting(self):
+        """
+        Check if TURBOFRESA refuses to wipe disk if another one with same serial (but different specs)
+        is already present to avoid conflicting information on the database
+        """
+        disk = self.dummy_disk
+        conflicting = dict(disk)
+
+        conflicting['model'] = "UNEXPECTED"
+
+        item = Item()
+        item.features = conflicting
+        item.location = 'Magazzino'
+
+        try:
+            self.tarallo_instance.add_item(item=item)
+            print("Item inserted successfully")
+        except ValidationError:
+            print("Item not inserted")
+            response = self.tarallo_instance.response
+            print("HTTP status code:", response.status_code, "\n" + response.json()['message'])
+            raise AssertionError("Failed to manually add disk to TARALLO")
+
+        assert turbofresa.add_to_tarallo(self.tarallo_instance, disk) is False
+
+    def test_update_broken(self):
+        """
+        Ensures that in case the disk results broken its TARALLO entry is updated
+        """
+        disk = dict(self.dummy_disk)
+
+        turbofresa.add_to_tarallo(self.tarallo_instance, disk)
+
+        disk['smart-data'] = SMART.fail
+
+        assert turbofresa.add_to_tarallo_broken(self.tarallo_instance, disk) is True
+
+
+class Test_Turbofresa:
+    """
+    Tests correct functioning of the parser and the TURBOFRESA
+    """
+    @classmethod
+    def setup_class(cls):
+        while True:
+            answer = input("\nSome of these tests require a USB key connected to the pc\n"
+                           "If you want to do the usb tests make sure only one is connected, "
+                           "otherwise make sure none is plugged. \n"
+                           "\nDo you want to execute USB tests? [y/N]")
+
+            if answer == 'y' or answer == 'Y':
+                cls.usb_present = True
+                break
+            elif answer == 'n' or answer == 'N' or answer == '':
+                cls.usb_present = False
+                break
+            else:
+                print(f'Unrecognized answer {answer}, type either "y" or "n"')
+
+    def test_smartctl_filegen(self):
+        import subprocess as sp
+
+        print('')
+
+        smartctl_path = os.getcwd() + "/smartctl_test"
+        filegen = os.getcwd() + "/smartctl_filegen.sh"
+        return_code = sp.run(["sudo", "-S", filegen, smartctl_path]).returncode
+        assert (return_code == 0), 'Error during disk detection'
+
+    def test_parser_no_usb(self):
+        disks = parse_disks(interactive=False, usbdebug=False)
+        filenum = len(os.listdir())
+        if self.usb_present is False:
+            assert filenum == len(disks)
+        else:
+            assert filenum == len(disks)+1
+
+    def test_parser_usb(self):
+        if self.usb_present is False:
+            raise SkipTest("USB not connected")
+
+
+if __name__ == "__main__":
+    test = Test_Tarallo()
+    test.setup_class()
+    test.setup()
+    test.test_add_disk()

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import os
+import subprocess as sp
 from dotenv import load_dotenv
 from pytarallo.Tarallo import Tarallo, Item
 from pytarallo.Errors import *
@@ -9,25 +10,21 @@ from nose.plugins.skip import SkipTest
 
 
 class Test_Tarallo:
-    """
-    Used to verify intereactions between TARALLO and TURBOFRESA
+    # Used to verify intereactions between TARALLO and TURBOFRESA
 
-    !!!WARNING!!!
-    Only run this on a test version of the TARALLO!!!
-    """
+    # !!!WARNING!!!
+    # Only run this on a test version of the TARALLO!!!
 
     def setup(self):
         if not self.connected:
             raise SkipTest("Not connected to TARALLO")
-
-    def teardown(self):
-        if self.connected:
+        else:
             codes = self.tarallo_instance.get_codes_by_feature('sn', self.dummy_disk['sn'])
             if len(codes) > 1:
                 for code in codes:
                     self.tarallo_instance.remove_item(code)
             elif len(codes) == 1:
-                self.tarallo_instance.remove_item(codes)
+                self.tarallo_instance.remove_item(codes[0])
 
     @classmethod
     def setup_class(cls):
@@ -37,7 +34,7 @@ class Test_Tarallo:
             'hdd-form-factor': '2.5-7mm',
             'model': 'TEST',
             'sata-ports-n': 1,
-            'smart-data': SMART.working,
+            'smart-data': SMART.working.value,
             'sn': 'USB123456',
             'type': 'ssd',
         }
@@ -59,9 +56,8 @@ class Test_Tarallo:
                 print("Couldn't connect to tarallo server")
 
     def test_add_disk(self):
-        """
-        Simple disk addition to TARALLO through the TURBOFRESA
-        """
+        # Simple disk addition to TARALLO through the TURBOFRESA
+
         disk = self.dummy_disk
 
         assert turbofresa.add_to_tarallo(self.tarallo_instance, disk) is True
@@ -70,15 +66,13 @@ class Test_Tarallo:
         assert len(disk_code) == 1
 
     def test_add_duplicate(self):
-        """
-        Check if TURBOFRESA refuses to add a duplicate disk (with the same specs),
-        but anyway continues to wipe it
-        """
+        # Check if TURBOFRESA refuses to add a duplicate disk (with the same specs),
+        # but anyway continues to wipe it
         disk = self.dummy_disk
 
         item = Item()
         item.features = disk
-        item.location = 'Magazzino'
+        item.location = 'Polito'
 
         try:
             self.tarallo_instance.add_item(item=item)
@@ -96,10 +90,9 @@ class Test_Tarallo:
         assert len(disk_code) == 1, "Disk added by error"
 
     def test_add_conflicting(self):
-        """
-        Check if TURBOFRESA refuses to wipe disk if another one with same serial (but different specs)
-        is already present to avoid conflicting information on the database
-        """
+        # Check if TURBOFRESA refuses to wipe disk if another one with same serial (but different specs)
+        # is already present to avoid conflicting information on the database
+
         disk = self.dummy_disk
         conflicting = dict(disk)
 
@@ -107,7 +100,7 @@ class Test_Tarallo:
 
         item = Item()
         item.features = conflicting
-        item.location = 'Magazzino'
+        item.location = 'Polito'
 
         try:
             self.tarallo_instance.add_item(item=item)
@@ -121,38 +114,16 @@ class Test_Tarallo:
         assert turbofresa.add_to_tarallo(self.tarallo_instance, disk) is False
 
     def test_update_broken(self):
-        """
-        Ensures that in case the disk results broken its TARALLO entry is updated
-        """
+        # Ensures that in case the disk results broken its TARALLO entry is updated
+
         disk = dict(self.dummy_disk)
-
         turbofresa.add_to_tarallo(self.tarallo_instance, disk)
-
-        disk['smart-data'] = SMART.fail
-
+        disk['smart-data'] = SMART.fail.value
         assert turbofresa.add_to_tarallo_broken(self.tarallo_instance, disk) is True
 
 
 class Test_Turbofresa:
-    """
-    Tests correct functioning of the parser and the TURBOFRESA
-    """
-    @classmethod
-    def setup_class(cls):
-        while True:
-            answer = input("\nSome of these tests require a USB key connected to the pc\n"
-                           "If you want to do the usb tests make sure only one is connected, "
-                           "otherwise make sure none is plugged. \n"
-                           "\nDo you want to execute USB tests? [y/N]")
-
-            if answer == 'y' or answer == 'Y':
-                cls.usb_present = True
-                break
-            elif answer == 'n' or answer == 'N' or answer == '':
-                cls.usb_present = False
-                break
-            else:
-                print(f'Unrecognized answer {answer}, type either "y" or "n"')
+    # Tests correct functioning of the parser and the TURBOFRESA
 
     def test_smartctl_filegen(self):
         import subprocess as sp
@@ -163,22 +134,27 @@ class Test_Turbofresa:
         filegen = os.getcwd() + "/smartctl_filegen.sh"
         return_code = sp.run(["sudo", "-S", filegen, smartctl_path]).returncode
         assert (return_code == 0), 'Error during disk detection'
-
-    def test_parser_no_usb(self):
-        disks = parse_disks(interactive=False, usbdebug=False)
-        filenum = len(os.listdir())
-        if self.usb_present is False:
-            assert filenum == len(disks)
-        else:
-            assert filenum == len(disks)+1
-
-    def test_parser_usb(self):
-        if self.usb_present is False:
-            raise SkipTest("USB not connected")
+        sp.run(['sudo', '-S', 'rm', '-rf', smartctl_path])
 
 
-if __name__ == "__main__":
-    test = Test_Tarallo()
-    test.setup_class()
-    test.setup()
-    test.test_add_disk()
+    def test_parser(self):
+        import sys
+        connected = set()
+        output = sp.check_output(["sudo", "-S", "df", "--output=source"]).decode(sys.stdout.encoding)
+
+        for line in output.splitlines():
+            if "/dev/" in line:
+                disk = line.split("/dev/")[1]
+                disk = ''.join(c for c in disk if not c.isdigit())
+                connected.add(disk)
+
+        disks = parse_disks(interactive=False, usbdebug=True)
+        assert len(connected) == len(disks)
+        for disk in disks:
+            assert disk["mount_point"] in connected
+
+    def test_ignore_sys_disks(self):
+        ignored = turbofresa.ignore_sys_disks()
+        assert len(ignored) > 0
+        for disk in ignored:
+            assert "sd" in disk

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -101,6 +101,8 @@ def ignore_user_disks() -> list:
         user_ignored = input("Insert disks to ignore separated by comma (sda,sdb,loop0,etc...): ")
         if user_ignored:
             return user_ignored.replace(" ", "").split(",")
+    else:
+        return []
 
 
 class Task(Process):

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -22,8 +22,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
-import json
+import os, sys
 import logging  # TODO: Add log messages
 from multiprocessing import Process
 import subprocess as sp
@@ -37,22 +36,71 @@ __version__ = '1.3'
 # Run parameters
 quiet = None
 simulate = None
-
 tarallo_instance = None
 
 
-def ask_confirm():
-    """
-    Asks the user if (s)he is sure of what (s)he's doing.
-    """
+def ask_confirm(disks: list):
+    print("\nThe following disks are going to be wiped:")
+
+    for d in disks:
+        print("- /dev/" + d['mount_point'])
+
     while True:
-        user_response = input("Are you 100% sure of what you're about to do? [N/y] ")
+        user_response = input("\nAre you 100% sure of what you're about to do? [N/y] ")
         if user_response.lower() == 'y':
             break
         elif user_response.lower() == 'n':
             exit(0)
         else:
             print("Unrecognized response... Asking again nicely.")
+
+
+def ignore_sys_disks() -> list:
+    """
+    Checks which disks have system partitions in them and asks if the user wishes to add
+    other disks to ignored
+    :return: Full list of ignored disks (system + user specified)
+    """
+
+    critical = [
+        "/boot",
+        "/home",
+        "/etc",
+        "/var",
+        "/lib",
+        "/root",
+        "/opt",
+        "/usr",
+        "/var"
+    ]
+
+    output = sp.check_output(["sudo", "-S", "df", "--output=source,target"]).decode(sys.stdout.encoding)
+
+    result = []
+    for line in output.splitlines():
+        source = line.split()[0]
+        target = line.split()[1]
+
+        if "/dev/sd" in source:
+            for partition in critical:
+                if partition in target or target == "/":
+                    disk = source.split("/dev/")[1]
+                    disk = ''.join(c for c in disk if not c.isdigit())
+                    if disk not in result:
+                        print(f'The partition "{target}" has been detected in "{source}", '
+                              f'the disk "{disk}" will be ignored')
+                        result.append(disk)
+                    break
+
+    return result
+
+
+def ignore_user_disks() -> list:
+    user_response = input("Do you wish to add more disks to ignore from wiping? [y/N] ")
+    if user_response.lower() == 'y':
+        user_ignored = input("Insert disks to ignore separated by comma (sda,sdb,loop0,etc...): ")
+        if user_ignored:
+            return user_ignored.replace(" ", "").split(",")
 
 
 class Task(Process):
@@ -63,7 +111,7 @@ class Task(Process):
         """
         :param disk: Disk object
         """
-        super().__init__(self)
+        super().__init__()
         self.disk = disk
 
     def run(self):
@@ -77,19 +125,28 @@ class Task(Process):
         and the broken hard drive is reported into the log file and informations
         are written to the T.A.R.A.L.L.O. database.
         """
-        exit_code = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o',
-                              self.disk['code'], "/dev/"+self.disk['mount_point']]).returncode
+        code = self.disk['code'][0]
+        mount_point = self.disk['mount_point']
+        filename = 'badblocks_error_logs/' + code + '.txt'
+        process = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, "/dev/"+mount_point])
+        process.communicate()
+        exit_code = process.returncode
+
+        global quiet
+        if not quiet:
+            print("Ended cleaning /dev/" + mount_point)
+
         # result = os.popen('cat %s' % self.disk.code).read()
         # if result == "":
-        if exit_code != 0:
-            sp.run(['rm', '-f', self.disk["code"]])
+        if exit_code == 0:
+            os.remove(filename)
             return True
         else:
             # TODO: Write on tarallo that the hard drive is broken
             # Write it in the turbofresa log file as well
             global tarallo_instance
-            disk['features']['smart-data'] = smartctl_parser.SMART.fail
-            add_to_tarallo_broken(tarallo_instance, disk['features'])
+            self.disk['features']['smart-data'] = smartctl_parser.SMART.fail
+            add_to_tarallo_broken(tarallo_instance, self.disk['features'])
             return False
 
 
@@ -102,7 +159,7 @@ def add_to_tarallo(instance: Tarallo.Tarallo, disk: dict) -> bool:
         False if there were multiple instances of it in the database
     """
 
-    print("===> Searching the T.A.R.A.L.L.O. databse for disk with serial number {}".format(disk['sn']))
+    print("\nSearching the T.A.R.A.L.L.O. databse for disk with serial number {}".format(disk['sn']))
     disk_code = instance.get_codes_by_feature('sn', disk['sn'])
 
     if len(disk_code) > 1:
@@ -111,24 +168,24 @@ def add_to_tarallo(instance: Tarallo.Tarallo, disk: dict) -> bool:
         return False
     elif len(disk_code) == 1:
         print(f"Disk with serial number {disk['sn']} already present in the database"
-              f"with the code {disk_code}")
-        item = instance.get_item(disk_code)
+              f"with the code {disk_code[0]}")
+        item = instance.get_item(disk_code[0])
         for key, value in item.features.items():
-            if key == 'smart_data' or key == 'smart_data_long':
+            if key == 'smart-data' or key == 'smart-data-long':
                 continue
             if value != disk[key]:
                 print("There's a conflict in the database for this disk")
                 print("Won't proceed until conflict is solved")
                 return False
-            print("The entry doesn't conflict with the current disk, proceeding anyway")
-            return True
+        print("The entry doesn't conflict with the current disk, proceeding anyway")
+        return True
     elif len(disk_code) == 0:
         print("No corresponding disk in the database")
-        print("===> Adding disk to the database")
 
+    print("Adding disk to the database")
     item = Item.Item()
     item.features = disk
-    item.location = 'Magazzino'  # TODO: maybe it can be set from config or a better default should be picked
+    item.location = 'Polito'  # TODO: maybe it can be set from config or a better default should be picked
 
     try:
         instance.add_item(item=item)
@@ -140,12 +197,12 @@ def add_to_tarallo(instance: Tarallo.Tarallo, disk: dict) -> bool:
         return False
 
     print("Successfully added the disk")
-    print("Disk code on the Database: " + instance.get_codes_by_feature('sn', disk['sn']))
+    print("Disk code on the Database: " + instance.get_codes_by_feature('sn', disk['sn'])[0])
     return True
 
 
 def add_to_tarallo_broken(instance: Tarallo.Tarallo, disk: dict) -> bool:
-    if disk['smart-data'] != smartctl_parser.SMART.fail:
+    if disk['smart-data'] != smartctl_parser.SMART.fail.value:
         print("Not a broken disk")
         return False
 
@@ -155,9 +212,11 @@ def add_to_tarallo_broken(instance: Tarallo.Tarallo, disk: dict) -> bool:
 
     disk_code = instance.get_codes_by_feature('sn', disk['sn'])
     try:
-        instance.update_features(disk_code, disk)
+        instance.update_features(disk_code[0], disk)
     except Errors.ValidationError:
         print("Failed to update informations")
+        response = instance.response
+        print("HTTP status code:", response.status_code, "\n" + response.json()['message'])
         return False
 
     return True
@@ -168,30 +227,50 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--shutdown', action='store_true', help='Shutdown the machine when everything is done.')
     parser.add_argument('-q', '--quiet', action='store_true', help='Run in background and suppress stdout.')
     parser.add_argument('-d', '--dry', action='store_true', help='Launch simulation.')
-    parser.add_argument('--usb', action='store_true', help='Launch simulation.')
+    parser.add_argument('--usb', action='store_true', help='Allow cleaning of usb drives (DEBUG ONLY!!!)')
     parser.add_argument('--version', '-V', action='version', version='%(prog)s v.' + __version__)
     parser.set_defaults(shutdown=False)
     parser.set_defaults(quiet=False)
     parser.set_defaults(dry=False)
     parser.set_defaults(usb=False)
     args = parser.parse_args()
+
     quiet = args.quiet
     simulate = args.dry
 
-    global tarallo_instance
+    print("The program will completely wipe any disk outside system ones connected to the current machine")
 
-    # ask_confirm()
+    # Preliminary operations
     if not quiet:
-        print("===> Detecting connected hard drives.")
+        print('\n\n===> Checking system disks')
+    ignored = ignore_sys_disks()
+    ignored = ignored + ignore_user_disks()
 
-    disks = smartctl_parser.parse_disks(interactive=True, usbdebug=args.usb)
+    # Disks parsing
+    if not quiet:
+        print("\n\n===> Detecting connected hard drives.")
+    disks = smartctl_parser.parse_disks(interactive=not quiet, usbdebug=args.usb, ignore=ignored)
+    if len(disks) == 0:
+        print("No valid device detected.")
+        exit(0)
     tasks = []
+    ask_confirm(disks)
 
     # Tarallo connection
+    if not quiet:
+        print('\n\n===> Connecting to T.A.R.A.L.L.O. database')
     load_dotenv()
-    tarallo_instance = Tarallo.Tarallo(os.getenv("TARALLO_URL"), os.getenv("TARALLO_TOKEN"))
+    try:
+        tarallo_instance = Tarallo.Tarallo(os.getenv("TARALLO_URL"), os.getenv("TARALLO_TOKEN"))
+    except:
+        print('Failed to connect to the database')
+        exit(1)
+    print('Successfully connected to the database')
 
-    # Adding disks to clean in queue and adding them to T.A.R.A.L.L.O if not present
+    # Adding disks to clean in queue and adding them to Tarallo if not present
+    if not quiet:
+        print('\n\n===> Adding disks to T.A.R.A.L.L.O.')
+
     for d in disks:
         disk = d['features']
 
@@ -201,22 +280,31 @@ if __name__ == '__main__':
 
         d['code'] = tarallo_instance.get_codes_by_feature('sn', disk['sn'])
         tasks.append(Task(d))
-        
+
+    # Time to TURBOFRESA
     if not quiet:
-        print("===> Cleaning disks")
+        print("\n\n===> Cleaning disks")
+
+    if not simulate:
+        if 'badblocks_error_logs' not in os.listdir(os.getcwd()):
+            os.mkdir('badblocks_error_logs')
+
     for t in tasks:
+        if not quiet:
+            print("Started cleaning /dev/" + t.disk['mount_point'])
         if not simulate:
             t.start()
-        else:
-            if not quiet:
-                print("Started cleaning")
 
     for t in tasks:
         if not simulate:
             t.join()
         else:
             if not quiet:
-                print("Ended cleaning")
+                print("Ended cleaning /dev/" + t.disk['mount_point'])
+
+    if simulate:
+        for d in disks:
+            tarallo_instance.remove_item(d['code'][0])
 
     if args.shutdown is True:
         if not simulate:

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -38,6 +38,8 @@ __version__ = '1.3'
 quiet = None
 simulate = None
 
+tarallo_instance = None
+
 
 def ask_confirm():
     """
@@ -51,6 +53,7 @@ def ask_confirm():
             exit(0)
         else:
             print("Unrecognized response... Asking again nicely.")
+
 
 class Task(Process):
     """
@@ -74,15 +77,20 @@ class Task(Process):
         and the broken hard drive is reported into the log file and informations
         are written to the T.A.R.A.L.L.O. database.
         """
-        exit_code = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', self.disk.code, self.disk.dev]).returncode
+        exit_code = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o',
+                              self.disk['code'], "/dev/"+self.disk['mount_point']]).returncode
         # result = os.popen('cat %s' % self.disk.code).read()
         # if result == "":
         if exit_code != 0:
-            sp.run(['rm', '-f', self.disk.code])
+            sp.run(['rm', '-f', self.disk["code"]])
+            return True
         else:
             # TODO: Write on tarallo that the hard drive is broken
             # Write it in the turbofresa log file as well
-            pass
+            global tarallo_instance
+            disk['features']['smart-data'] = smartctl_parser.SMART.fail
+            add_to_tarallo_broken(tarallo_instance, disk['features'])
+            return False
 
 
 def add_to_tarallo(instance: Tarallo.Tarallo, disk: dict) -> bool:
@@ -90,11 +98,38 @@ def add_to_tarallo(instance: Tarallo.Tarallo, disk: dict) -> bool:
     Adds disk to Tarallo database
     :param instance: Tarallo instance where to add the disk
     :param disk: disk to add to the database
-    :return: True if added successfully, False otherwise
+    :return: True if added successfully or it was already present,
+        False if there were multiple instances of it in the database
     """
+
+    print("===> Searching the T.A.R.A.L.L.O. databse for disk with serial number {}".format(disk['sn']))
+    disk_code = instance.get_codes_by_feature('sn', disk['sn'])
+
+    if len(disk_code) > 1:
+        print("Multiple disks in the database corresponding to the serial number: " + disk['sn'])
+        print("Won't proceed until conflict is solved")
+        return False
+    elif len(disk_code) == 1:
+        print(f"Disk with serial number {disk['sn']} already present in the database"
+              f"with the code {disk_code}")
+        item = instance.get_item(disk_code)
+        for key, value in item.features.items():
+            if key == 'smart_data' or key == 'smart_data_long':
+                continue
+            if value != disk[key]:
+                print("There's a conflict in the database for this disk")
+                print("Won't proceed until conflict is solved")
+                return False
+            print("The entry doesn't conflict with the current disk, proceeding anyway")
+            return True
+    elif len(disk_code) == 0:
+        print("No corresponding disk in the database")
+        print("===> Adding disk to the database")
+
     item = Item.Item()
     item.features = disk
     item.location = 'Magazzino'  # TODO: maybe it can be set from config or a better default should be picked
+
     try:
         instance.add_item(item=item)
         print("Item inserted successfully")
@@ -102,6 +137,27 @@ def add_to_tarallo(instance: Tarallo.Tarallo, disk: dict) -> bool:
         print("Item not inserted")
         response = instance.response
         print("HTTP status code:", response.status_code, "\n" + response.json()['message'])
+        return False
+
+    print("Successfully added the disk")
+    print("Disk code on the Database: " + instance.get_codes_by_feature('sn', disk['sn']))
+    return True
+
+
+def add_to_tarallo_broken(instance: Tarallo.Tarallo, disk: dict) -> bool:
+    if disk['smart-data'] != smartctl_parser.SMART.fail:
+        print("Not a broken disk")
+        return False
+
+    if add_to_tarallo(instance, disk) is False:
+        print("Failed to update informations")
+        return False
+
+    disk_code = instance.get_codes_by_feature('sn', disk['sn'])
+    try:
+        instance.update_features(disk_code, disk)
+    except Errors.ValidationError:
+        print("Failed to update informations")
         return False
 
     return True
@@ -112,41 +168,38 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--shutdown', action='store_true', help='Shutdown the machine when everything is done.')
     parser.add_argument('-q', '--quiet', action='store_true', help='Run in background and suppress stdout.')
     parser.add_argument('-d', '--dry', action='store_true', help='Launch simulation.')
+    parser.add_argument('--usb', action='store_true', help='Launch simulation.')
     parser.add_argument('--version', '-V', action='version', version='%(prog)s v.' + __version__)
     parser.set_defaults(shutdown=False)
     parser.set_defaults(quiet=False)
     parser.set_defaults(dry=False)
+    parser.set_defaults(usb=False)
     args = parser.parse_args()
     quiet = args.quiet
     simulate = args.dry
 
+    global tarallo_instance
+
     # ask_confirm()
     if not quiet:
         print("===> Detecting connected hard drives.")
-    disks = smartctl_parser.main()
+
+    disks = smartctl_parser.parse_disks(interactive=True, usbdebug=args.usb)
     tasks = []
 
     # Tarallo connection
     load_dotenv()
-    instance = Tarallo.Tarallo(os.getenv("TARALLO_URL"), os.getenv("TARALLO_TOKEN"))
+    tarallo_instance = Tarallo.Tarallo(os.getenv("TARALLO_URL"), os.getenv("TARALLO_TOKEN"))
 
     # Adding disks to clean in queue and adding them to T.A.R.A.L.L.O if not present
     for d in disks:
-        print("===> Searching the T.A.R.A.L.L.O. databse for disk with serial number {}".format(d['sn']))
-        disk_code = instance.get_codes_by_feature('sn', d['sn'])
-        if len(disk_code) > 1:
-            print("Multiple disks in the database corresponding to the serial number: " + d['sn'])
-            print("Won't proceed to disk wiping until conflict is solved")
-            continue
-        elif len(disk_code) == 0:
-            print("No corresponding disk in the database")
-            print("===> Adding disk to the database")
-            if not add_to_tarallo(instance=instance, disk=d):
-                print("Skipping wiping of this disk")
-                continue
-        elif len(disk_code) == 1:
-            print("Disk already present in the database")
+        disk = d['features']
 
+        if add_to_tarallo(tarallo_instance, disk) is False:
+            print("Something went wrong with Disk addition to database, skipping to the next one")
+            continue
+
+        d['code'] = tarallo_instance.get_codes_by_feature('sn', disk['sn'])
         tasks.append(Task(d))
         
     if not quiet:


### PR DESCRIPTION
Fix #16 

Changes:
- Added recent changes from PERACOTTA (https://github.com/WEEE-Open/peracotta/commit/eaba2de3ed8a671466bea8231c4da61cceb6b415) to allow better disk port detection
- Disks will now be added to TARALLO if not present. It will refuse to add them if already present and it won't wipe disks if there are multiple instances of it in the database (asking to first solve the conflict in the db)

TODO:
- Testing disk wiping


Tried with SSD in my current work machine and it successfully added it. If somebody has some disks to wipe it could now be tested to see if the whole process works as intended.