### PR TITLE
Various corrections and resolving #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ If you want to piallare some hard drives, edit `/etc/sudoers` file and add:
 `piall ALL=(ALL) NOPASSWD : /sbin/shutdown`  
 `piall ALL=(ALL) NOPASSWD : /sbin/badblocks`  
 `piall ALL=(ALL) NOPASSWD : /sbin/smartctl`  
+
+## CONFIGURATION
+Before running the program you have to create a .env file with the fields `TARALLO_URL` and `TARALLO_TOKEN` with the ones of your T.A.R.A.L.L.O. instance. The file formatting is as follows:
+
+```
+export TARALLO_URL=http://localhost:8080
+export TARALLO_TOKEN=super-secret-token-nobody-should-actually-know
+```
+If you're running inside pipenv you might need to restart the virtual shell to allow it to update the environmental variables.

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -62,9 +62,9 @@ def parse_disks(interactive: bool = False, ignore: list = [], usbdebug: bool = F
     """
 
     disks = []
-    smartctl_path = os.getcwd() + "/smartctl"
+    smartctl_path = os.path.join(os.getcwd(), "smartctl")
 
-    filegen = os.getcwd() + "/smartctl_filegen.sh"
+    filegen = os.path.join(os.getcwd(), "smartctl_filegen.sh")
     return_code = sp.run(["sudo", "-S", filegen, smartctl_path]).returncode
     assert (return_code == 0), 'Error during disk detection'
 
@@ -81,12 +81,12 @@ def parse_disks(interactive: bool = False, ignore: list = [], usbdebug: bool = F
             if ignored is True:
                 if interactive is True:
                     print("Disk mounted at /dev/"+mount_point+" ignored")
-                os.remove(smartctl_path+"/"+filename)
+                os.remove(os.path.join(smartctl_path, filename))
                 continue
 
             # File reading
             try:
-                with open(smartctl_path + "/" + filename, 'r') as f:
+                with open(os.path.join(smartctl_path, filename), 'r') as f:
                     output = f.read()
             except FileNotFoundError:
                 raise InputFileNotFoundError(smartctl_path)
@@ -105,8 +105,8 @@ def parse_disks(interactive: bool = False, ignore: list = [], usbdebug: bool = F
 
             disk.dev = filename.split("smartctl-dev-")[1].split(".txt")[0]
 
-            old_filename = "smartctl/" + filename
-            new_filename = "smartctl/" + disk.serial_number + ".txt"
+            old_filename = os.path.join("smartctl/", filename)
+            new_filename = os.path.join("smartctl/", disk.serial_number) + ".txt"
             os.rename(old_filename, new_filename)
 
             disks.append(disk)

--- a/tests.py
+++ b/tests.py
@@ -130,8 +130,8 @@ class Test_Turbofresa:
 
         print('')
 
-        smartctl_path = os.getcwd() + "/smartctl_test"
-        filegen = os.getcwd() + "/smartctl_filegen.sh"
+        smartctl_path = os.path.join(os.getcwd(), "/smartctl_test")
+        filegen = os.path.join(os.getcwd(), "/smartctl_filegen.sh")
         return_code = sp.run(["sudo", "-S", filegen, smartctl_path]).returncode
         assert (return_code == 0), 'Error during disk detection'
         sp.run(['sudo', '-S', 'rm', '-rf', smartctl_path])

--- a/tests.py
+++ b/tests.py
@@ -42,12 +42,14 @@ class Test_Tarallo:
         load_dotenv()
         tarallo_url = os.getenv("TARALLO_URL")
         tarallo_token = os.getenv("TARALLO_TOKEN")
+
         try:
             cls.tarallo_instance = Tarallo(tarallo_url, tarallo_token)
+            status = cls.tarallo_instance.status()
         except:
             cls.connected = False
         else:
-            if cls.tarallo_instance.status() == 200:
+            if status == 200:
                 cls.connected = True
             else:
                 cls.connected = False
@@ -130,8 +132,8 @@ class Test_Turbofresa:
 
         print('')
 
-        smartctl_path = os.path.join(os.getcwd(), "/smartctl_test")
-        filegen = os.path.join(os.getcwd(), "/smartctl_filegen.sh")
+        smartctl_path = os.path.join(os.getcwd(), "smartctl_test")
+        filegen = os.path.join(os.getcwd(), "smartctl_filegen.sh")
         return_code = sp.run(["sudo", "-S", filegen, smartctl_path]).returncode
         assert (return_code == 0), 'Error during disk detection'
         sp.run(['sudo', '-S', 'rm', '-rf', smartctl_path])
@@ -140,13 +142,10 @@ class Test_Turbofresa:
     def test_parser(self):
         import sys
         connected = set()
-        output = sp.check_output(["sudo", "-S", "df", "--output=source"]).decode(sys.stdout.encoding)
+        output = sp.check_output(["lsblk", "-nd", "-o", "NAME"]).decode(sys.stdout.encoding)
 
         for line in output.splitlines():
-            if "/dev/" in line:
-                disk = line.split("/dev/")[1]
-                disk = ''.join(c for c in disk if not c.isdigit())
-                connected.add(disk)
+            connected.add(line)
 
         disks = parse_disks(interactive=False, usbdebug=True)
         assert len(connected) == len(disks)

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -136,8 +136,7 @@ class Task(Process):
             if line.startswith(mount_point):
                 line = line.split()
                 if len(line) > 1:
-                    sp.run(["sudo", "umount", os.path.join("/dev", mount_point)])
-                    break
+                    sp.run(["sudo", "umount", os.path.join("/dev", line[0])])
 
         # Cleaning disk
         filename = 'badblocks_error_logs/' + code + '.txt'

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -81,13 +81,13 @@ def ignore_sys_disks() -> list:
     for line in output.splitlines():
         line = line.split()
         if len(line) > 1:
-            partition = line[0]
-            mount_point = line[1]
+            mount_point = line[0]
+            partition = line[1]
             for critical in criticals:
-                if critical in mount_point or mount_point == "/":
-                    disk = ''.join(c for c in partition if not c.isdigit())
+                if critical in partition or partition == "/":
+                    disk = ''.join(c for c in mount_point if not c.isdigit())
                     if disk not in result:
-                        print(f'The partition "/dev/{partition}" has been detected in "{mount_point}", '
+                        print(f'The partition "{partition}" has been detected in "/dev/{mount_point}", '
                               f'the disk "{disk}" will be ignored')
                         result.append(disk)
                     break
@@ -131,12 +131,13 @@ class Task(Process):
         mount_point = self.disk['mount_point']
 
         # Unmounting disk
-        output = sp.check_output(["lsblk", "-ln", "-o", "NAME,MOUNTPOINT", "|", "grep", mount_point]).decode(sys.stdout.encoding)
+        output = sp.check_output(["lsblk", "-ln", "-o", "NAME,MOUNTPOINT"]).decode(sys.stdout.encoding)
         for line in output.splitlines():
-            line = line.split()
-            if len(line) > 1:
-                sp.run(["umount", os.path.join("/dev", mount_point)])
-                break
+            if line.startswith(mount_point):
+                line = line.split()
+                if len(line) > 1:
+                    sp.run(["sudo", "umount", os.path.join("/dev", mount_point)])
+                    break
 
         # Cleaning disk
         filename = 'badblocks_error_logs/' + code + '.txt'

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -130,7 +130,7 @@ class Task(Process):
         code = self.disk['code'][0]
         mount_point = self.disk['mount_point']
         filename = 'badblocks_error_logs/' + code + '.txt'
-        process = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, "/dev/"+mount_point])
+        process = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, os.path.join("/dev", mount_point)])
         process.communicate()
         exit_code = process.returncode
 

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -129,6 +129,16 @@ class Task(Process):
         """
         code = self.disk['code'][0]
         mount_point = self.disk['mount_point']
+
+        # Unmounting disk
+        output = sp.check_output(["lsblk", "-ln", "-o", "NAME,MOUNTPOINT", "|", "grep", mount_point]).decode(sys.stdout.encoding)
+        for line in output.splitlines():
+            line = line.split()
+            if len(line) > 1:
+                sp.run(["umount", os.path.join("/dev", mount_point)])
+                break
+
+        # Cleaning disk
         filename = 'badblocks_error_logs/' + code + '.txt'
         process = sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, os.path.join("/dev", mount_point)])
         process.communicate()
@@ -138,8 +148,6 @@ class Task(Process):
         if not quiet:
             print("Ended cleaning /dev/" + mount_point)
 
-        # result = os.popen('cat %s' % self.disk.code).read()
-        # if result == "":
         if exit_code == 0:
             os.remove(filename)
             return True


### PR DESCRIPTION
Corrections made:
- Using `lsblk` instead of `df` to detect possible system partititions. The command allows to scan only devices in /dev/ and includes more partitions (like swap) 
- As suggested, large usage of `os.paht.join()` to avoid accidental errors in the creation of path strings
- Updated README. Fix #30 

After a bit of testing I could confirm that badblocks can still point at a disk after using `umount /dev/sdX` using the same mount point. Since i didn't have these problems on Arch i would ask @e-caste (or whoever has Ubuntu installed) to test the change before the merge so I can make all the necessary corrections. Fix #31 