### PR TITLE
Addressing issues #34 and #35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 venv/
 smartctl
+badblocks_error_logs
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 venv/
+smartctl
 __pycache__

--- a/smartctl_filegen.sh
+++ b/smartctl_filegen.sh
@@ -17,7 +17,7 @@ rm -f "$OUTPATH"/*.txt
 DISKZ=($(lsblk -d -I 8 -o NAME -n))
 echo Found $((${#DISKZ[@]})) disks
 for d in "${DISKZ[@]}"; do
-	  smartctl -x /dev/$d > "$OUTPATH/smartctl-dev-$d.txt"
+	  smartctl -d sat,auto -T verypermissive -x /dev/$d > "$OUTPATH/smartctl-dev-$d.txt"
 done
 
 exit 0

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -63,6 +63,8 @@ def parse_disks(interactive: bool = False, ignore: list = [], usbdebug: bool = F
 
     disks = []
     smartctl_path = os.path.join(os.getcwd(), "smartctl")
+    if not os.path.exists(smartctl_path):
+        os.makedirs(smartctl_path)
 
     filegen = os.path.join(os.getcwd(), "smartctl_filegen.sh")
     return_code = sp.run(["sudo", "-S", filegen, smartctl_path]).returncode

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -268,6 +268,11 @@ def tarallo_conversion(disks: list):
     """
     result = []
     for disk in disks:
+        if disk.smart_data.value == "ok":
+            working = "yes"
+        else:
+            working = "no"
+
         if disk.type == "ssd":  # ssd
             this_disk = {
                 "type": "ssd",
@@ -277,7 +282,8 @@ def tarallo_conversion(disks: list):
                 "wwn": disk.wwn,
                 "sn": disk.serial_number,
                 "capacity-byte": disk.capacity,
-                "smart-data": disk.smart_data.value
+                "smart-data": disk.smart_data.value,
+                "working": working
             }
             if disk.smart_data_long is not SMART.not_available:
                 this_disk['notes'] = disk.smart_data_long
@@ -293,7 +299,8 @@ def tarallo_conversion(disks: list):
                 # tell some functions how to convert it to human-readable format
                 "capacity-decibyte": disk.capacity,
                 "spin-rate-rpm": disk.rotation_rate,
-                "smart-data": disk.smart_data.value
+                "smart-data": disk.smart_data.value,
+                "working": working
             }
         if disk.form_factor is not None:
             this_disk["hdd-form-factor"] = disk.form_factor

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -230,7 +230,7 @@ def read_smartctl(smartctl_output):
                 disk.brand = brand
 
         elif "Serial Number:" in line:
-            disk.serial_number = line.split("Serial Number:")[1].strip()
+            disk.serial_number = normalize_sn(line.split("Serial Number:")[1].strip())
 
         elif "LU WWN Device Id:" in line:
             disk.wwn = line.split("LU WWN Device Id:")[1].strip()
@@ -373,6 +373,13 @@ def remove_prefix(prefix, text):
     if text.startswith(prefix):
         return text[len(prefix):]
     return text
+
+
+def normalize_sn(sn: str) -> str:
+    # TODO: add more normalization criteria
+    sn = sn.replace('wd', '')
+    sn = sn.replace('WD', '')
+    return sn
 
 
 def main():

--- a/smartctl_parser.py
+++ b/smartctl_parser.py
@@ -136,6 +136,19 @@ def dummy_disk():
     return disk
 
 
+def check_complete(disk):
+    """
+    Check if the disk passed contains all the necessary information to be added to TARALLO
+    """
+    essentials = ['smart_data', 'brand', 'model', 'type', 'capacity', 'form_factor', 'port', 'serial_number']
+
+    for ess in essentials:
+        if getattr(disk, ess) == "":
+            return False
+
+    return True
+
+
 def read_smartctl(smartctl_output):
 
     disk = Disk()

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -32,14 +32,14 @@ class TaralloInterface:
             return False
 
         print("Adding disk to the database")
-        item = Item.Item()
-        item.features = disk
-        item.location = 'Polito'  # TODO: maybe it can be set from config or a better default should be picked
 
         # Catch any errors thrown by the TARALLO in case some disaster happens
         try:
             # Base on the presence of duplicates, add or update
             if duplicates == 0:
+                item = Item.Item()
+                item.features = disk
+                item.location = 'Polito'  # TODO: maybe it can be set from config or a better default should be picked
                 self.instance.add_item(item=item)
             elif duplicates == 1:
                 # TODO: to avoid checking twice the database for the disk we could return the code from check_duplicates

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -21,13 +21,10 @@ class TaralloInterface:
 
     def add_disk(self, disk: dict) -> bool:
         """
-        Adds disk to Tarallo database
-        :param instance: Tarallo instance where to add the disk
+        Adds or updates disk to Tarallo database
         :param disk: disk to add to the database
         :return: True if added/updated successfully, False otherwise
         """
-
-        #TODO: modify it to an 'add or update' version
 
         # Don't do any operation if there are conflicting entries in the db
         duplicates = self.check_duplicate(disk)
@@ -39,14 +36,18 @@ class TaralloInterface:
         item.features = disk
         item.location = 'Polito'  # TODO: maybe it can be set from config or a better default should be picked
 
+        # Catch any errors thrown by the TARALLO in case some disaster happens
         try:
+            # Base on the presence of duplicates, add or update
             if duplicates == 0:
                 self.instance.add_item(item=item)
             elif duplicates == 1:
+                # TODO: to avoid checking twice the database for the disk we could return the code from check_duplicates
                 code = self.instance.get_codes_by_feature('sn', disk['sn'])[0]
                 self.instance.update_features(code, disk)
             print("Item inserted successfully")
         except Errors.ValidationError:
+            # Simply return False and don't crash if there's some error
             print("Item not inserted")
             response = self.instance.response
             print("HTTP status code:", response.status_code, "\n" + response.json()['message'])

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -82,3 +82,7 @@ class TaralloInterface:
         elif len(disk_code) == 0:
             print("No corresponding disk in the database")
             return True
+
+    def get_instance(self):
+        """Returns an instance of the tarallo connection if interested in acting on that manually"""
+        return self.instance

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -43,8 +43,7 @@ class TaralloInterface:
                 self.instance.add_item(item=item)
             elif duplicates == 1:
                 # TODO: to avoid checking twice the database for the disk we could return the code from check_duplicates
-                code = self.instance.get_codes_by_feature('sn', disk['sn'])[0]
-                self.instance.update_features(code, disk)
+                self.update_disk(disk)
             print("Item inserted successfully")
         except Errors.ValidationError:
             # Simply return False and don't crash if there's some error
@@ -92,6 +91,20 @@ class TaralloInterface:
         elif len(disk_code) == 0:
             print("No corresponding disk in the database")
             return 0
+
+    def update_disk(self, disk):
+        code = self.instance.get_codes_by_feature('sn', disk['sn'])[0]
+        remote = self.instance.get_item(code).features
+
+        upload = {}
+
+        for feature_to_upload in ['brand', 'model', 'variant', 'capacity-decibyte', 'spin-rate-rpm', 'sn', 'wwn',
+                                  'form-factor-hdd', 'type']:
+            if feature_to_upload not in remote and feature_to_upload in disk:
+                upload[feature_to_upload] += disk[feature_to_upload]
+            if upload:
+                self.instance.update_features(code, upload)
+
 
     def get_instance(self):
         """Returns an instance of the tarallo connection if interested in acting on that manually"""

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -1,20 +1,23 @@
 from pytarallo import Tarallo, Errors, Item
 
-class TaralloInterface:
-    instance = None
 
-    @staticmethod
-    def connect(url: str, token: str):
-        interface = TaralloInterface()
+class TaralloInterface:
+    def __init__(self, instance=None):
+        self.instance = instance
+
+    def connect(self, url: str, token: str):
+        if self.instance is not None:
+            print("Already connected to a T.A.R.A.L.L.O. instance")
+            return False
 
         print("Trying to connect to the T.A.R.A.L.L.O. database")
         try:
-            interface.instance = Tarallo.Tarallo(url, token)
+            self.instance = Tarallo.Tarallo(url, token)
         except:
             print('Failed to connect to the database')
-            return None
-        print("Connection successful!")
-        return interface
+            return False
+        print("Successfully connected to the database")
+        return True
 
     def add_disk(self, disk: dict) -> bool:
         """
@@ -25,7 +28,7 @@ class TaralloInterface:
             False if there were multiple instances of it in the database
         """
 
-        if not self.check_on_tarallo(disk):
+        if not self.check_duplicate(disk):
             return False
 
         print("Adding disk to the database")
@@ -46,10 +49,11 @@ class TaralloInterface:
         print("Disk code on the Database: " + self.instance.get_codes_by_feature('sn', disk['sn'])[0])
         return True
 
-    def check_on_tarallo(self, disk: dict) -> bool:
+    def check_duplicate(self, disk: dict) -> bool:
         """
-        Verify if there's a disk that might conflict
-        with what we want to insert into the TARALLO
+        Verify if there's a disk that might conflict with what we want to insert into the TARALLO
+        :param disk: the disk that might give a conflict
+        :return: true if it's safe to add/update the disk, false otherwise
         """
 
         print("\nSearching the T.A.R.A.L.L.O. databse for disk with serial number {}".format(disk['sn']))

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -3,6 +3,19 @@ from pytarallo import Tarallo, Errors, Item
 class TaralloInterface:
     instance = None
 
+    @staticmethod
+    def connect(url: str, token: str):
+        interface = TaralloInterface()
+
+        print("Trying to connect to the T.A.R.A.L.L.O. database")
+        try:
+            interface.instance = Tarallo.Tarallo(url, token)
+        except:
+            print('Failed to connect to the database')
+            return None
+        print("Connection successful!")
+        return interface
+
     def add_disk(self, disk: dict) -> bool:
         """
         Adds disk to Tarallo database

--- a/tarallo_interface.py
+++ b/tarallo_interface.py
@@ -1,0 +1,67 @@
+from pytarallo import Tarallo, Errors, Item
+
+class TaralloInterface:
+    instance = None
+
+    def add_disk(self, disk: dict) -> bool:
+        """
+        Adds disk to Tarallo database
+        :param instance: Tarallo instance where to add the disk
+        :param disk: disk to add to the database
+        :return: True if added successfully or it was already present,
+            False if there were multiple instances of it in the database
+        """
+
+        if not self.check_on_tarallo(disk):
+            return False
+
+        print("Adding disk to the database")
+        item = Item.Item()
+        item.features = disk
+        item.location = 'Polito'  # TODO: maybe it can be set from config or a better default should be picked
+
+        try:
+            self.instance.add_item(item=item)
+            print("Item inserted successfully")
+        except Errors.ValidationError:
+            print("Item not inserted")
+            response = self.instance.response
+            print("HTTP status code:", response.status_code, "\n" + response.json()['message'])
+            return False
+
+        print("Successfully added the disk")
+        print("Disk code on the Database: " + self.instance.get_codes_by_feature('sn', disk['sn'])[0])
+        return True
+
+    def check_on_tarallo(self, disk: dict) -> bool:
+        """
+        Verify if there's a disk that might conflict
+        with what we want to insert into the TARALLO
+        """
+
+        print("\nSearching the T.A.R.A.L.L.O. databse for disk with serial number {}".format(disk['sn']))
+        disk_code = self.instance.get_codes_by_feature('sn', disk['sn'])
+
+        # if there's already more than 1 corresponding disk in the TARALLO, don't add
+        if len(disk_code) > 1:
+            print("Multiple disks in the database corresponding to the serial number: " + disk['sn'])
+            print("Won't proceed until conflict is solved")
+            return False
+        # if there is exactly one disk, check if we're simply changing the status or there's a conflict
+        elif len(disk_code) == 1:
+            print(f"Disk with serial number {disk['sn']} already present in the database"
+                  f"with the code {disk_code[0]}")
+            item = self.instance.get_item(disk_code[0])
+            # checking for conflicing features
+            for key, value in item.features.items():
+                if key == 'smart-data' or key == 'smart-data-long':
+                    continue  # we don't care if it has a different status
+                if value != disk[key]:
+                    print("There's a conflict in the database for this disk")
+                    print("Won't proceed until conflict is solved")
+                    return False
+            print("The entry doesn't conflict with the current disk, safe to add")
+            return True
+        elif len(disk_code) == 0:
+            print("No corresponding disk in the database")
+            return True

--- a/tests.py
+++ b/tests.py
@@ -78,6 +78,9 @@ class Test_Tarallo:
         """Try to add a non-conflicting duplicate"""
         disk = self.dummy_disk
 
+        # Check that there are no duplicates
+        assert self.tarallo_interface.check_duplicate(disk) == 0, "TaralloInterface is detecting a duplicate"
+
         # Manually add the dummy through pytarallo
         item = Item()
         item.features = disk
@@ -92,7 +95,7 @@ class Test_Tarallo:
             raise AssertionError("Failed to manually add disk through pytarallo")
 
         # Verify that check_duplicate doesn't detect a conflicting entry
-        assert self.tarallo_interface.check_duplicate(disk) is True, "TaralloInterface is detecting a duplicate"
+        assert self.tarallo_interface.check_duplicate(disk) == 1, "TaralloInterface is detecting a conflicting duplicate"
 
         # Try to add the duplicate through TaralloInterface
         assert self.tarallo_interface.add_disk(disk) is True, "Failed to add disk through TaralloInterface"
@@ -123,7 +126,7 @@ class Test_Tarallo:
             raise AssertionError("Failed to manually add disk to TARALLO")
 
         # Check if conflict is detected
-        assert self.tarallo_interface.check_duplicate(disk) is False, "TaralloInterface didn't detect the conflict"
+        assert self.tarallo_interface.check_duplicate(disk) == -1, "TaralloInterface didn't detect the conflict"
 
         # Check if TaralloInterface refuses to add the disk
         assert self.tarallo_interface.add_disk(disk) is False, "TaralloInterface added the disk anyway"

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -162,17 +162,18 @@ class Task(Process):
                 success = False
                 p.kill()
             finally:
+                features = self.disk['features']
                 if success is True:
                     os.remove(filename)
-                    self.disk['features']['data-erased'] = 'yes'
-                    self.disk['features']['surface-scan'] = 'pass'
-                    self.disk['features']['smart-data'] = smartctl_parser.SMART.working
+                    features['data-erased'] = 'yes'
+                    features['surface-scan'] = 'pass'
+                    features['smart-data'] = smartctl_parser.SMART.working
                 else:
-                    self.disk['features']['smart-data'] = smartctl_parser.SMART.fail
-                    self.disk['features']['working'] = 'unknown'
+                    features['smart-data'] = smartctl_parser.SMART.fail
+                    features['working'] = 'unknown'
 
                 if tarallo_instance is not None:
-                    tarallo_instance.add_disk(self.disk['features'])
+                    tarallo_instance.add_disk(features)
 
                 return success
 

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -251,7 +251,7 @@ if __name__ == '__main__':
 
     if simulate and tarallo_instance is not None:
         for d in disks:
-            tarallo_instance.remove_item(d['code'][0])
+            tarallo_instance.get_instance().remove_item(d['code'][0])
 
     if args.shutdown is True:
         if not simulate:

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -233,6 +233,8 @@ if __name__ == '__main__':
 
     for d in disks:
         disk = d['features']
+        disk['erased'] = None
+        disk['surface-scan'] = None
 
         if tarallo_instance is not None:
             if tarallo_instance.add_disk(disk) is False:

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -150,7 +150,10 @@ class Task(Process):
         with sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, os.path.join("/dev", mount_point)]) as p:
             success = False
             try:
-                p.wait(timeout=10 * 60)  # TODO: calculate timeout based on disk size, leave 10 mins as placeholder
+                disk_gb = self.disk['features']['capacity-byte'] / 1024**2
+                mins_per_gb = 1  # TODO: could be set with a config file?
+                timeout = 60 * mins_per_gb * disk_gb
+                p.wait(timeout=timeout)
                 if p.returncode == 0:
                     success = True
 

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -173,7 +173,7 @@ class Task(Process):
                     features['smart-data'] = smartctl_parser.SMART.working
                 else:
                     features['smart-data'] = smartctl_parser.SMART.fail
-                    features['working'] = 'unknown'
+                    features['working'] = 'maybe'
 
                 if tarallo_instance is not None:
                     tarallo_instance.add_disk(features)

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -164,13 +164,17 @@ class Task(Process):
             finally:
                 if success is True:
                     os.remove(filename)
-                    return True
+                    self.disk['features']['data-erased'] = 'yes'
+                    self.disk['features']['surface-scan'] = 'pass'
+                    self.disk['features']['smart-data'] = smartctl_parser.SMART.working
                 else:
-                    # TODO: Write on tarallo that the hard drive is broken
-                    # Write it in the turbofresa log file as well
                     self.disk['features']['smart-data'] = smartctl_parser.SMART.fail
+                    self.disk['features']['working'] = 'unknown'
+
+                if tarallo_instance is not None:
                     tarallo_instance.add_disk(self.disk['features'])
-                    return False
+
+                return success
 
 
 if __name__ == '__main__':

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -147,11 +147,11 @@ class Task(Process):
                     sp.run(["sudo", "umount", os.path.join("/dev", line[0])])
 
         # Cleaning disk
-        with sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, os.path.join("/dev", mount_point)]) as p:
+        with sp.Popen(['sudo', '-S', 'badblocks', '-s', '-w', '-t', '0x00', '-o', filename, os.path.join("/dev", mount_point)]) as p:
             success = False
             try:
                 disk_gb = self.disk['features']['capacity-byte'] / 1024**3
-                mins_per_gb = 1  # TODO: could be set with a config file?
+                mins_per_gb = 2  # TODO: could be set with a config file?
                 timeout = 60 * mins_per_gb * disk_gb
                 p.wait(timeout=timeout)
                 if p.returncode == 0:

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -229,19 +229,23 @@ if __name__ == '__main__':
         tasks.append(Task(d))
 
     # Time to TURBOFRESA
+
     if not quiet:
         print("\n\n===> Cleaning disks")
 
+    # Create badblock logs folder if not present
     if not simulate:
         if 'badblocks_error_logs' not in os.listdir(os.getcwd()):
             os.mkdir('badblocks_error_logs')
 
+    # Start all tasks
     for t in tasks:
         if not quiet:
             print("Started cleaning /dev/" + t.disk['mount_point'])
         if not simulate:
             t.start()
 
+    # Wait for threads completition
     for t in tasks:
         if not simulate:
             t.join()
@@ -249,6 +253,7 @@ if __name__ == '__main__':
             if not quiet:
                 print("Ended cleaning /dev/" + t.disk['mount_point'])
 
+    # TODO: evaluate if removing this piece
     if simulate and tarallo_instance is not None:
         for d in disks:
             tarallo_instance.get_instance().remove_item(d['code'][0])

--- a/turbofresa.py
+++ b/turbofresa.py
@@ -150,7 +150,7 @@ class Task(Process):
         with sp.Popen(['sudo', 'badblocks', '-w', '-t', '0x00', '-o', filename, os.path.join("/dev", mount_point)]) as p:
             success = False
             try:
-                disk_gb = self.disk['features']['capacity-byte'] / 1024**2
+                disk_gb = self.disk['features']['capacity-byte'] / 1024**3
                 mins_per_gb = 1  # TODO: could be set with a config file?
                 timeout = 60 * mins_per_gb * disk_gb
                 p.wait(timeout=timeout)


### PR DESCRIPTION
This PR can be divided in 3 important points

#### 1. Implementation of TaralloInterface()
This class provides a better abstraction of the communications between pytarallo and the Turbofresa. Since, at the current time, the new release of pytarallo that allows to interact with Tarallo v2 is still under development, doing any testing is currently impossible.
Most of the methods of this class are either a copy or a modification of the ones present before this PR. They have been moved to a new file to avoid clogging `turbofresa.py` with needless methods and avoid confusion.
During development some tests have been rewritten to comply with the new type of interactions.

#### 2. Fix #34 
The flag `--no-tarallo` has been added to block the interactions with the Tarallo database. The inclusion of TaralloInterface made it easier: we simply keep an instance of the class to interact with if needed, or we keep the variable Null to avoid any interaction (through simple if statements)

#### 3. Address #35 
The program has modified so disks are added to Tarallo with the required parameters during all the phases of the process, as described in detail in #35 .
In particular, to identify a failstate of `badblocks`, the program observes two things:
- The exit code of the process: if it's different from 0 we assume that `badblocks` failed and that disk presents problems
- A timeout: if the program takes too long to finish the execution is aborted and we identify it as failed. The timeout (in seconds) is calculated dynamically with the following formula:
`timeout = 60 * mins_per_gb * disk_gb`
where:
  - `mins_per_gb` is a constant (currently =2) that expresses how many minutes we want to wait at most for every GB of the drive. The value has been calculated based on some testing with a simple bash script: it ran `badblocks` for numerous times on a 32GB USB 3.0 drive and calculated the average time of execution for every run, resulting in 32 minutes, or 1 minute per GB. The value has been doubled to allow more time to make sure the program didn't get stuck just for some time.
  - `disk_gb' is simply the size of the disk converted in GB
